### PR TITLE
Install openvmtools on VMware machines (again)

### DIFF
--- a/modules/hardware/manifests/init.pp
+++ b/modules/hardware/manifests/init.pp
@@ -16,7 +16,7 @@ include apt
 #
 class hardware {
 
-  if $::productname == 'VMware Virtual Platform' {
+  if $::productname =~ /VMware/ {
     # OpenBSD does not use open-vm-tools, see the vmt(4) driver.
     if $::operatingsystem != 'OpenBSD' {
       package { 'open-vm-tools':


### PR DESCRIPTION
Productname changed, so use more generic match to determine if a VM is
on VMware or not