### PR TITLE
Fix alertmanager-systemctl-daemon-reload spelling mistake

### DIFF
--- a/modules/dhmon/manifests/alertmanager.pp
+++ b/modules/dhmon/manifests/alertmanager.pp
@@ -47,7 +47,7 @@ class dhmon::alertmanager {
   #Systemctl config
   file { '/etc/systemd/system/alertmanager.service':
     ensure  => file,
-    notify  => Exec['alertmanger-systemctl-daemon-reload'],
+    notify  => Exec['alertmanager-systemctl-daemon-reload'],
     content => template('dhmon/alertmanager.service.erb'),
   }
   -> file { '/etc/default/alertmanager':


### PR DESCRIPTION
Fixes a resource spelling error introduced in #33 