### PR TITLE
Kubernetes remove accidental taint

### DIFF
--- a/modules/kubernetes/templates/init.yaml.erb
+++ b/modules/kubernetes/templates/init.yaml.erb
@@ -3,10 +3,6 @@ kind: InitConfiguration
 nodeRegistration:
   name: "<%= @hostname %>"
   criSocket: "/var/run/dockershim.sock"
-  taints:
-  - key: "kubeadmNode"
-    value: "master"
-    effect: "NoSchedule"
 apiEndpoint:
   advertiseAddress: "<%= @ipaddress %>"
   bindPort: 6443

--- a/modules/resolvconf.py
+++ b/modules/resolvconf.py
@@ -33,7 +33,7 @@ def generate(host, *args):
         resolvers.remove(host)
         # Use an external resolver by default so we do not create deadlocks
         # when bootstrapping the environment from scratch.
-        info['nameservers'].append('8.8.8.8')
+        info['nameservers'].append('1.1.1.1')
 
     ips = lib.resolve_nodes_to_ip(resolvers)
     info['nameservers'].extend([ips[x][0] for x in resolvers])


### PR DESCRIPTION
A taint slipped into the kubeadm config for the master node, remove this to allow scheduling of kube-router. 