### PR TITLE
Do not default $ldap by default

### DIFF
--- a/modules/apache/manifests/init.pp
+++ b/modules/apache/manifests/init.pp
@@ -14,7 +14,7 @@
 #   not do LDAP authentication.
 #
 
-class apache($ldap = nil) {
+class apache($ldap) {
 
   package { 'apache2':
     ensure => installed,


### PR DESCRIPTION
This should translate better into templates when not defined.
Otherwise nil becomes string("nil").