### PR TITLE
CIDR mask and python3 support

### DIFF
--- a/modules/swbootd/templates/config.py.erb
+++ b/modules/swbootd/templates/config.py.erb
@@ -118,13 +118,14 @@ def generate(switch, model_id):
   #
   # Template function definition
   #
-  cfg = tempita.Template(file(model.template).read())
+  cfg = tempita.Template(open(model.template).read())
   return \
       cfg.substitute(
             hostname=switch,
             model=model,
             mgmt_ip=mgmt['ip'],
             mgmt_mask=mgmt['mask'],
+            mgmt_mask_cidr=mgmt['mask_cidr'],
             mgmt_gw=mgmt['gw'],
             mgmt_vlanid=mgmt['vlanid'],
             vlanid=vlanid,
@@ -162,6 +163,7 @@ AND h.name = s.switch_name AND n_mgmt.node_id = h.network_id'''
   mgmt = {}
   mgmt['ip'] = mgmt_ip
   mgmt['mask'] = str(network.netmask())
+  mgmt['mask_cidr'] = str(network.subnet())
   mgmt['gw'] = str(network.host_first())
   mgmt['vlanid'] = mgmt_vlan
 


### PR DESCRIPTION
Template variable for CIDR mask.
Change file() to open() to support python3.