### PR TITLE
WireGuard

### DIFF
--- a/modules/wireguard.py
+++ b/modules/wireguard.py
@@ -1,0 +1,10 @@
+# Copyright 2024 dhtech
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file
+
+
+def generate(host, *args):
+    return {'wireguard': None}
+
+# vim: ts=4: sts=4: sw=4: expandtab

--- a/modules/wireguard/manifests/init.pp
+++ b/modules/wireguard/manifests/init.pp
@@ -44,7 +44,7 @@ class wireguard {
   file { '/tmp/wireguard/wireguard-clients.yaml':
     ensure  => directory,
     recurse => remote,
-    source  => "puppet:///svn/${current_event}/services/wireguard-clients.yaml",
+    source  => "puppet:///svn/$::{current_event}/services/wireguard-clients.yaml",
 }
 
 

--- a/modules/wireguard/manifests/init.pp
+++ b/modules/wireguard/manifests/init.pp
@@ -28,7 +28,7 @@ class wireguard {
   }
 
 
- exec { 'add-key':
+  exec { 'add-key':
     command => '/usr/bin/wg set wg0 listen-port 51820 private-key /etc/wireguard/privkey',
     require => Exec['create-key'],        # require 'apt-update' before installing
   }

--- a/modules/wireguard/manifests/init.pp
+++ b/modules/wireguard/manifests/init.pp
@@ -6,8 +6,8 @@ class wireguard {
 
   # Install wireguard package
   package { 'wireguard':
-    require => Exec['apt-update'],        # require 'apt-update' before installing
     ensure  => installed,
+    require => Exec['apt-update'],        # require 'apt-update' before installing
   }
 
   # Create wireguard interface

--- a/modules/wireguard/manifests/init.pp
+++ b/modules/wireguard/manifests/init.pp
@@ -37,8 +37,8 @@ class wireguard {
 # Set wireguard interface IP
   exec { 'set wg interface IP':
     require => Package['wireguard'],
-    command => '/usr/bin/ip address add dev wg0 77.80.200.129/25',
-    unless  => '/usr/bin/ip addr show wg0 | grep 77.80.200.129/25'
+    command => '/usr/bin/ip address add dev wg0 77.80.229.133/25',
+    unless  => '/usr/bin/ip addr show wg0 | grep 77.80.229.133/25'
   }
 
   file { '/tmp/wireguard/wireguard-clients.yaml':

--- a/modules/wireguard/manifests/init.pp
+++ b/modules/wireguard/manifests/init.pp
@@ -17,6 +17,22 @@ class wireguard {
     unless  => '/usr/bin/ip link show wg0'
   }
 
+  exec { 'create-privkey':
+    command => '/usr/bin/wg pubkey < /etc/wireguard/privkey > /etc/wireguard/pubkey',
+    unless  => '/usr/bin/ls /etc/wireguard/privkey'
+  }
+
+  exec { 'create-pubkey':
+    command => '/usr/bin/wg genkey > /etc/wireguard/privkey',
+    unless  => '/usr/bin/ls /etc/wireguard/privkey'
+  }
+
+
+ exec { 'add-key':
+    command => '/usr/bin/wg set wg0 listen-port 51820 private-key /etc/wireguard/privkey',
+    require => Exec['create-key'],        # require 'apt-update' before installing
+  }
+
 
 # Set wireguard interface IP
   exec { 'set wg interface IP':
@@ -25,11 +41,18 @@ class wireguard {
     unless  => '/usr/bin/ip addr show wg0 | grep 77.80.200.129/25'
   }
 
-# Specify all clients usable IPs 77.80.200.130 - 77.80.200.254
-  $clients = [
-    { nick => 'felix', ip => '77.80.200.130', key => '5Dk2crqm8A51OQ1blVK701YMZj33U+GONpmLrr0LWkM=' },
-    { nick => 'washington', ip => '77.80.200.131', key => 'Z8aCXv4ydIhUEtvH+NJv39mAMGiS8uF8oNgCoIByAFI=' },
-  ]
+  file { '/etc/wireguard/privkey':
+    ensure  => directory,
+    recurse => remote,
+    source  => "puppet:///svn/${current_event}/services/wireguard-clients.yaml",
+    unless  => '/usr/bin/ls /etc/wireguard/privkey'
+}
+
+  file { '/tmp/wireguard/wireguard-clients.yaml':
+    ensure  => directory,
+    recurse => remote,
+    source  => "puppet:///svn/${current_event}/services/wireguard-clients.yaml",
+}
 
 
 # Build the wg0 config file will all clients from previous step

--- a/modules/wireguard/manifests/init.pp
+++ b/modules/wireguard/manifests/init.pp
@@ -1,0 +1,48 @@
+class wireguard {
+  # Execute 'apt-get update'
+  exec { 'apt-update':                    # exec resource named 'apt-update'
+    command => '/usr/bin/apt-get update'  # command this resource will run
+  }
+
+  # Install wireguard package
+  package { 'wireguard':
+    require => Exec['apt-update'],        # require 'apt-update' before installing
+    ensure => installed,
+  }
+
+  # Create wireguard interface
+  exec { 'create':
+    require => Package['wireguard'],
+    command => '/usr/bin/ip link add dev wg0 type wireguard',
+   unless => '/usr/bin/ip link show wg0'
+  }
+
+
+# Set wireguard interface IP
+  exec { 'set wg interface IP':
+    require => Package['wireguard'],
+    command => '/usr/bin/ip address add dev wg0 77.80.200.129/25',
+    unless => '/usr/bin/ip addr show wg0 | grep 77.80.200.129/25'
+  }
+
+# Specify all clients usable IPs 77.80.200.130 - 77.80.200.254
+  $clients = [
+    { nick => 'felix', ip => '77.80.200.130', key => '5Dk2crqm8A51OQ1blVK701YMZj33U+GONpmLrr0LWkM=' },
+    { nick => 'washington', ip => '77.80.200.131', key => 'Z8aCXv4ydIhUEtvH+NJv39mAMGiS8uF8oNgCoIByAFI=' },
+  ]
+
+
+# Build the wg0 config file will all clients from previous step
+  file { 'setConf':
+    ensure  => file,
+    path    => "/etc/wireguard/wg0.conf",
+    notify  => Exec[syncConf],
+    content => template('wireguard/templates/wg0.conf.erb'),
+  }
+
+# Sync changes towards the wg0 interface
+  exec { 'syncConf':
+    require => Package['wireguard'],
+    command => '/usr/bin/wg syncconf wg0 /etc/wireguard/wg0.conf',
+  }
+}

--- a/modules/wireguard/manifests/init.pp
+++ b/modules/wireguard/manifests/init.pp
@@ -44,7 +44,7 @@ class wireguard {
   file { '/tmp/wireguard/wireguard-clients.yaml':
     ensure  => directory,
     recurse => remote,
-    source  => "puppet:///svn/$::{current_event}/services/wireguard-clients.yaml",
+    source  => 'puppet:///svn/$::{current_event}/services/wireguard-clients.yaml',
 }
 
 

--- a/modules/wireguard/manifests/init.pp
+++ b/modules/wireguard/manifests/init.pp
@@ -35,7 +35,7 @@ class wireguard {
 # Build the wg0 config file will all clients from previous step
   file { 'setConf':
     ensure  => file,
-    path    => "/etc/wireguard/wg0.conf",
+    path    => '/etc/wireguard/wg0.conf',
     notify  => Exec[syncConf],
     content => template('wireguard/templates/wg0.conf.erb'),
   }

--- a/modules/wireguard/manifests/init.pp
+++ b/modules/wireguard/manifests/init.pp
@@ -7,14 +7,14 @@ class wireguard {
   # Install wireguard package
   package { 'wireguard':
     require => Exec['apt-update'],        # require 'apt-update' before installing
-    ensure => installed,
+    ensure  => installed,
   }
 
   # Create wireguard interface
   exec { 'create':
     require => Package['wireguard'],
     command => '/usr/bin/ip link add dev wg0 type wireguard',
-   unless => '/usr/bin/ip link show wg0'
+    unless  => '/usr/bin/ip link show wg0'
   }
 
 
@@ -22,7 +22,7 @@ class wireguard {
   exec { 'set wg interface IP':
     require => Package['wireguard'],
     command => '/usr/bin/ip address add dev wg0 77.80.200.129/25',
-    unless => '/usr/bin/ip addr show wg0 | grep 77.80.200.129/25'
+    unless  => '/usr/bin/ip addr show wg0 | grep 77.80.200.129/25'
   }
 
 # Specify all clients usable IPs 77.80.200.130 - 77.80.200.254

--- a/modules/wireguard/manifests/init.pp
+++ b/modules/wireguard/manifests/init.pp
@@ -41,13 +41,6 @@ class wireguard {
     unless  => '/usr/bin/ip addr show wg0 | grep 77.80.200.129/25'
   }
 
-  file { '/etc/wireguard/privkey':
-    ensure  => directory,
-    recurse => remote,
-    source  => "puppet:///svn/${current_event}/services/wireguard-clients.yaml",
-    unless  => '/usr/bin/ls /etc/wireguard/privkey'
-}
-
   file { '/tmp/wireguard/wireguard-clients.yaml':
     ensure  => directory,
     recurse => remote,

--- a/modules/wireguard/templates/wg0.conf.erb
+++ b/modules/wireguard/templates/wg0.conf.erb
@@ -1,6 +1,6 @@
 [Interface]
 PrivateKey = UJywHJtV58X11nF6zmouBCmfKfKbH4iggugRA/Th/k8=
-ListenPort = 51923
+ListenPort = 51820
 
 
 <% @clients.each do |client| -%>

--- a/modules/wireguard/templates/wg0.conf.erb
+++ b/modules/wireguard/templates/wg0.conf.erb
@@ -1,4 +1,5 @@
 [Interface]
+#Just placeholder privkey will be pulled from vault
 PrivateKey = UJywHJtV58X11nF6zmouBCmfKfKbH4iggugRA/Th/k8=
 ListenPort = 51820
 

--- a/modules/wireguard/templates/wg0.conf.erb
+++ b/modules/wireguard/templates/wg0.conf.erb
@@ -1,13 +1,10 @@
-[Interface]
-#Just placeholder privkey will be pulled from vault
-PrivateKey = UJywHJtV58X11nF6zmouBCmfKfKbH4iggugRA/Th/k8=
-ListenPort = 51820
+<% require 'yaml' %>
+<% clients = YAML.load_file('/tmp/wireguard/wireguard-clients.yaml')['clients'] %>
 
-
-<% @clients.each do |client| -%>
-#<%= client['nick'] %>
+<% clients.each do |nick, client| -%>
+# <%= nick %>
 [Peer]
-PublicKey = <%= client['key'] %>
+PublicKey = <%= client['publickey'] %>
 AllowedIPs = <%= client['ip'] %>
 
 <% end -%>

--- a/modules/wireguard/templates/wg0.conf.erb
+++ b/modules/wireguard/templates/wg0.conf.erb
@@ -1,0 +1,12 @@
+[Interface]
+PrivateKey = UJywHJtV58X11nF6zmouBCmfKfKbH4iggugRA/Th/k8=
+ListenPort = 51923
+
+
+<% @clients.each do |client| -%>
+#<%= client['nick'] %>
+[Peer]
+PublicKey = <%= client['key'] %>
+AllowedIPs = <%= client['ip'] %>
+
+<% end -%>


### PR DESCRIPTION
Moved client key to SVN
Client keys is now read from SVN
Server priv/pub key is now generated on sever when server is deployed.