### PR TITLE
Add Prometheus datasource provisioning for Grafana

### DIFF
--- a/modules/grafana.py
+++ b/modules/grafana.py
@@ -6,9 +6,18 @@ import lib
 
 
 def generate(host, *args):
+    prometheus_servers = {}
+    for server in sorted(lib.get_nodes_with_package('prometheus').keys()):
+        try:
+            domain = lib.get_domain(server).lower()
+        except lib.NoDomainError:
+            domain = 'unknown'
+        prometheus_servers[server] = domain
+
     info = {
     'grafana': {
-        'current_event': lib.get_current_event()
+        'current_event': lib.get_current_event(),
+        'prometheus_servers': prometheus_servers,
         }
     }
 

--- a/modules/grafana/manifests/init.pp
+++ b/modules/grafana/manifests/init.pp
@@ -11,7 +11,7 @@
 # for package details such as default paths etc.
 #
 
-class grafana($current_event) {
+class grafana($current_event, $prometheus_servers = []) {
 
   # Adding the apt repository
   package { 'apt-transport-https':
@@ -108,6 +108,15 @@ class grafana($current_event) {
       ].join(' '),
       refreshonly => true,
     }
+  }
+
+  # Prometheus datasource provisioning
+  file { 'grafana-prometheus-datasources':
+    path    => '/etc/grafana/provisioning/datasources/prometheus.yaml',
+    content => template('grafana/prometheus-datasource.yaml.erb'),
+    mode    => '0644',
+    require => Package['grafana'],
+    notify  => Service['grafana-server'],
   }
 
   # Setting up the Apache proxy

--- a/modules/grafana/templates/prometheus-datasource.yaml.erb
+++ b/modules/grafana/templates/prometheus-datasource.yaml.erb
@@ -1,0 +1,12 @@
+# Managed by Puppet - do not edit manually
+apiVersion: 1
+
+datasources:
+<% @prometheus_servers.each do |server, domain| -%>
+  - name: prometheus_<%= domain %>
+    type: prometheus
+    url: http://<%= server %>:9090
+    access: proxy
+    isDefault: false
+    editable: false
+<% end -%>


### PR DESCRIPTION
Query all Prometheus servers across domains and provision them as named datasources (prometheus_<domain>) via Grafana's file-based provisioning.